### PR TITLE
Update & delete behavior not consistent with other adapters when record does not exist.

### DIFF
--- a/SailsRest.js
+++ b/SailsRest.js
@@ -6,8 +6,7 @@
 var async   = require('async'),
     restify = require('restify'),
     url     = require('url'),
-    _       = require('lodash'),
-    util    = require('util');
+    _       = require('lodash');
 
 module.exports = (function(){
   "use strict";


### PR DESCRIPTION
When a delete or update is executed against a non-existent record, the sails-mongo, sails-disk, and sails-memory adapters (and possibly others as well, though I haven't investigated any aside from the three I mentioned), no error is passed to the callback function.  sails-rest, however, passes an error back to the callback after receiving a 404 from the restful service.  This patch seeks to make the behavior of sails-rest consistent with the other adapters.
