### PR TITLE
Handle error when checking for 404 status code from target service, but no response is received.

### DIFF
--- a/SailsRest.js
+++ b/SailsRest.js
@@ -168,7 +168,7 @@ module.exports = (function(){
       var path = uri.replace(connection.url.href, '/');
 
       var callback = function(err, req, res, obj) {
-        if (err && res.statusCode !== 404) {
+        if (err && (typeof res === 'undefined' || res === null || res.statusCode !== 404)) {
           cb(err);
         }
         else if (err && res.statusCode === 404) { 


### PR DESCRIPTION
If no response is received from the target service, SailsRest.js handles this scenario gracefully.
