### PR TITLE
Update connection example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ module.exports.adapters = {
   rest: {
     module: 'sails-rest',
     type: 'json',             // expected response type (json | string | http)
-    host: 'api.somewhere.io', // api host
+    hostname: 'api.url.io',   // api host
     port: 80,                 // api port
     protocol: 'http',         // HTTP protocol (http | https)
     rejectUnauthorized: true, // prevent https connections that use a self-signed certificate


### PR DESCRIPTION
This PR updates the example connection object within the readme to use `hostname` instead of `host`. The problem with using `host` is that any port number provided will be ignored which could cause confusion. 

For example: 

``` js
url.format({
  hostname: 'example.com',
  port: 1337, 
  protocol: 'http'
})
// out: http://example.com:1337

url.format({
  host: 'example.com',
  port: 1337, 
  protocol: 'http'
})
// out: http://example.com
```
