### PR TITLE
fix: RestError causes 'circular structure' error when Sails tries to convert it to JSON

### DIFF
--- a/SailsRest.js
+++ b/SailsRest.js
@@ -218,7 +218,7 @@ module.exports = (function() {
             responseErrorCode = res && /^(4|5)\d+$/.test(res.statusCode.toString());
 
         if (err && ( res === undefined || res === null || responseErrorCode ) ) {
-          restError = new RestError(err.message, {req: req, res: res, data: data});
+          restError = new RestError(err.message, {originalError: err, data: data});
           callback(restError);
         } else {
           if (methodName === 'find') {


### PR DESCRIPTION
The fix is to omit the `req`/`res` objects when constructing the `RestError` object. Instead, the `originalError` object is attached as meta data.