### PR TITLE
Removed unused `async` dependency and updated `restify`

### DIFF
--- a/SailsRest.js
+++ b/SailsRest.js
@@ -4,7 +4,6 @@
 ---------------------------------------------------------------*/
 
 var Errors = require('waterline-errors').adapter,
-  async = require('async'),
   restify = require('restify'),
   url = require('url'),
   _ = require('lodash'),

--- a/package.json
+++ b/package.json
@@ -24,9 +24,8 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "async": "0.1.22",
     "lodash": "^2.4.1",
-    "restify": "2.6.0",
+    "restify": "^2.8.5",
     "underscore.inflections": "^0.2.1",
     "underscore.string": "^2.3.3",
     "waterline-errors": "^0.10.0"


### PR DESCRIPTION
`restify@2.6.0` was causing errors under node v0.11.*. I'm not sure why it was locked to `2.6.0` specifically, but upgrading to the latest version solved the node errors and didn't seem to cause any other issues.

Also noticed that `async` isn't being used so I removed it.