### PR TITLE
Pass all parameters to (before|after)FormatResult(s).

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ module.exports.adapters = {
       update: 'put',
       destroy: 'del'
     },
-    beforeFormatResult: function(result){return result},    // alter result prior to formatting
-    afterFormatResult: function(result){return result},     // alter result after formatting
-    beforeFormatResults: function(results){return results}, // alter results prior to formatting
-    afterFormatResults: function(results){return results},  // alter results after formatting
+    beforeFormatResult: function (result, collectionName, config, definition) { return result; },    // alter result prior to formatting
+    afterFormatResult: function (result, collectionName, config, definition) { return result; },     // alter result after formatting
+    beforeFormatResults: function (results, collectionName, config, definition) { return results; }, // alter results prior to formatting
+    afterFormatResults: function (results, collectionName, config, definition) { return results; },  // alter results after formatting
     cache: {                  // optional cache engine
       engine : require('someCacheEngine')
     }

--- a/SailsRest.js
+++ b/SailsRest.js
@@ -35,7 +35,7 @@ module.exports = (function() {
    */
   function formatResult(result, collectionName, config, definition) {
     if (_.isFunction(config.beforeFormatResult)) {
-      result = config.beforeFormatResult(result);
+      result = config.beforeFormatResult(result, collectionName, config, definition);
     }
 
     _.each(definition, function(def, key) {
@@ -45,7 +45,7 @@ module.exports = (function() {
     });
 
     if (_.isFunction(config.afterFormatResult)) {
-      result = config.afterFormatResult(result);
+      result = config.afterFormatResult(result, collectionName, config, definition);
     }
 
     return result;
@@ -61,7 +61,7 @@ module.exports = (function() {
    */
   function formatResults(results, collectionName, config, definition) {
     if (_.isFunction(config.beforeFormatResults)) {
-      results = config.beforeFormatResults(results);
+      results = config.beforeFormatResults(results, collectionName, config, definition);
     }
 
     results.forEach(function(result) {
@@ -69,7 +69,7 @@ module.exports = (function() {
     });
 
     if (_.isFunction(config.afterFormatResults)) {
-      results = config.afterFormatResults(results);
+      results = config.afterFormatResults(results, collectionName, config, definition);
     }
 
     return results;


### PR DESCRIPTION
It is useful for the formatResult callbacks to have access to the config and model definitions, which allows for more flexible/reusable callbacks.