### PR TITLE
BeforeRequest config callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![image_squidhome@2x.png](http://i.imgur.com/RIvu9.png) 
+![image_squidhome@2x.png](http://i.imgur.com/RIvu9.png)
 
 # SailsRest
 
@@ -17,7 +17,7 @@ $ npm install sails-rest
 sails-rest is compatible with Sails.js v0.9.0 and above.
 
 For Sails.js v0.9 please use v0.0.3 version of sails-rest.
- 
+
 For Sails.js v0.10 please use v0.0.4 version of sails-rest (or newer).
 
 ## Sails Configuration
@@ -50,6 +50,7 @@ module.exports.adapters = {
     afterFormatResult: function (result, collectionName, config, definition) { return result; },     // alter result after formatting
     beforeFormatResults: function (results, collectionName, config, definition) { return results; }, // alter results prior to formatting
     afterFormatResults: function (results, collectionName, config, definition) { return results; },  // alter results after formatting
+    beforeRequest: function(config) { return config; }, // Alter config prior to request gets run
     cache: {                  // optional cache engine
       engine : require('someCacheEngine')
     }

--- a/SailsRest.js
+++ b/SailsRest.js
@@ -223,6 +223,11 @@ module.exports = (function() {
     // Add pathname to connection
     config.pathname = pathname;
 
+    // Let user customize config before request is run
+    if (_.isFunction(config.beforeRequest)) {
+      config = config.beforeRequest(config);
+    }
+
     // Format URI
     var uri = url.format(config);
 
@@ -294,7 +299,8 @@ module.exports = (function() {
       beforeFormatResult: null,
       afterFormatResult: null,
       beforeFormatResults: null,
-      afterFormatResults: null
+      afterFormatResults: null,
+      beforeRequest: null
     },
 
     registerConnection: function(connection, collections, cb) {


### PR DESCRIPTION
I have added the beforeRequest callback to the config to give the user possibility to update necessary config parameters before the request gets run. 

Could for example be used if you need to add some query parameters to all requests. 