### PR TITLE
Made pluralisation of pathname optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![image_squidhome@2x.png](http://i.imgur.com/RIvu9.png) 
+![image_squidhome@2x.png](http://i.imgur.com/RIvu9.png)
 
 # SailsRest
 
@@ -17,7 +17,7 @@ $ npm install sails-rest
 sails-rest is compatible with Sails.js v0.9.0 and above.
 
 For Sails.js v0.9 please use v0.0.3 version of sails-rest.
- 
+
 For Sails.js v0.10 please use v0.0.4 version of sails-rest (or newer).
 
 ## Sails Configuration
@@ -40,6 +40,7 @@ module.exports.adapters = {
     resource: null,           // resource path to use (overrides model name)
     action: null,             // action to use for the given resource ([resource]/run)
     query: {},                // query parameters to provide with all GET requests, accepts an object or a function (view below).
+    pluralize: true,          // Set to false to prevent from pluralizing the model name
     methods: {                // overrides default HTTP methods used for each CRUD action
       create: 'post',
       find: 'get',

--- a/SailsRest.js
+++ b/SailsRest.js
@@ -170,7 +170,7 @@ module.exports = (function() {
     // if resource name not set in config,
     // try to get it from pluralized form of collectionName
     if (!config.resource) {
-      config.resource = _i.pluralize(collectionName);
+      config.resource = config.pluralize === true ? _i.pluralize(collectionName) : collectionName;
     }
 
     pathname = config.getPathname(config, restMethod, values, options);
@@ -284,6 +284,7 @@ module.exports = (function() {
       resource: null,
       action: null,
       query: {},
+      pluralize: true,
       methods: {
         create: 'post',
         find: 'get',


### PR DESCRIPTION
Not all APIs pluralize their endpoints. Therefor have I added a config flag to turn on and off pluralisation of the methodName when resource is not set. By default this flag will be set to true to not break old implementations. 