### PR TITLE
Allow for data transforming before sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ module.exports.adapters = {
     beforeFormatResults: function (results, collectionName, config, definition) { return results; }, // alter results prior to formatting
     afterFormatResults: function (results, collectionName, config, definition) { return results; },  // alter results after formatting
     beforeRequest: function(config) { return config; }, // Alter config prior to request gets run
+    transformData: function(opt, config, methodName) { return opt; }, // Alter outgoing data prior to request being run
     cache: {                  // optional cache engine
       engine : require('someCacheEngine')
     }

--- a/SailsRest.js
+++ b/SailsRest.js
@@ -304,7 +304,8 @@ module.exports = (function() {
       afterFormatResult: null,
       beforeFormatResults: null,
       afterFormatResults: null,
-      beforeRequest: null
+      beforeRequest: null,
+      transformData: null
     },
 
     registerConnection: function(connection, collections, cb) {

--- a/SailsRest.js
+++ b/SailsRest.js
@@ -267,6 +267,9 @@ module.exports = (function() {
 
       // Make request via restify
       if (opt) {
+        if (_.isFunction(config.transformData)) {
+          opt = config.transformData(opt, config, methodName);
+        }
         connection[restMethod](path, opt, cb);
       } else {
         connection[restMethod](path, cb);


### PR DESCRIPTION
An API that I am working with requires that new instances are enclosed in a parent object. This data transform step allows for this.