### PR TITLE
Pass semantic test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
     "express": "3.x",
     "mocha": "^1.10.0",
     "multer": "^0.1.4",
+    "sails-memory": "^0.10.4",
     "waterline-adapter-tests": "^0.10.0"
   },
   "waterlineAdapter": {
     "waterlineVersion": "^0.10.0",
     "interfaces": [
-      "semantic",
-      "queryable"
+      "semantic"
     ]
   }
 }


### PR DESCRIPTION
Hi,
if you mind pass official test suite for waterline adapter, here is first step. After few changes all semantic tests are green. Additionally support app use now another adapter for waterline (memory) to be sure api is consistent.

I am not sure queryable interface is necessary, but it should be possible to pass it as well.