### PR TITLE
return Array to waterline even if response body is empty.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -133,7 +133,7 @@ Connection.find = function (connection, collection, options, cb) {
       }
       // Waterline requires that `find` will return an array.
       // Here we ensure that response body is converted to an array if required.
-      if(!err && !_.isEmpty(res.body)){
+      if(!err){
         if(!Array.isArray(res.body)){
           res.body = [res.body];
         }


### PR DESCRIPTION
All tests passes after this change.

This resolves a crashing issue on empty response bodies. The reason to avoid turning an empty response into an empty array was not clear, there still might be a case for it.
